### PR TITLE
Move a quote so it properly launches kfeditor on windows

### DIFF
--- a/builder
+++ b/builder
@@ -721,14 +721,14 @@ function compile ()
 	msg "compilation"
 	
 	if is_true "$ArgHoldEditor"; then
-		CMD //C "$(cygpath -w "$KFEditor") make $StripSourceArg -useunpublished"
+		CMD //C "$(cygpath -w "$KFEditor")" make $StripSourceArg -useunpublished
 		parse_log "$(find_log)"
 		if ! compiled; then
 			die "compilation failed"
 		fi
 		msg "${GRN}successfully compiled${DEF}"
 	else
-		CMD //C "$(cygpath -w "$KFEditor") make $StripSourceArg -useunpublished" &
+		CMD //C "$(cygpath -w "$KFEditor")" make $StripSourceArg -useunpublished &
 		PID="$!"
 		while ps -p "$PID" &> /dev/null
 		do


### PR DESCRIPTION
When the quote is at the end it parses the whole string as a program/command
instead of trying to start the whole string
(args counted as path, which results in `'C:\program' is not recognized as an internal or external command,
operable program or batch file.`)

after:
start `C:\program files (x86)\steam\steamapps\common\killingfloor2\Binaries\Win64\KFEditor.exe`
with args: `make $StripSourceArg -useunpublished`
before:
start `C:\program files (x86)\steam\steamapps\common\killingfloor2\Binaries\Win64\KFEditor.exe make $StripSourceArg -useunpublished`

You'd have to test this on Linux since I don't have the game installed there